### PR TITLE
[OBSOLETE] [RHO-4290] Consolidate logging interface to require channel to be specified

### DIFF
--- a/PadoruLogger/Debug.cs
+++ b/PadoruLogger/Debug.cs
@@ -112,7 +112,23 @@ namespace Padoru.Diagnostics
         {
             InternalLog(LogType.Error, message, channel, context);
         }
+        
+        
+        public static void LogException(Exception e, string channel)
+        {
+            LogException(null, e, channel);
+        }
 
+        public static void LogException(object messageHeader, string channel, Exception e)
+        {
+            LogException(messageHeader, e, channel);
+        }
+
+        public static void LogException(Exception e, string channel, object context)
+        {
+            LogException(null, e, channel, context);
+        }
+        
         public static void LogException(object messageHeader, Exception e, string channel, object context=null)
         {
             var message = messageHeader != null ? $"{messageHeader}. {e.Message}" : e.Message;

--- a/PadoruLogger/Debug.cs
+++ b/PadoruLogger/Debug.cs
@@ -8,6 +8,7 @@ namespace Padoru.Diagnostics
 {
     public static class Debug
     {
+        private const string INTERNAL_CHANNEL_NAME = "PadoruDebug";
         private static UnityConsoleOutput defaultUnityConsoleOutput;
         private static List<RuntimePlatform> unsupportedPlatforms;
         private static IStackTraceFormatter stackTraceFormatter;
@@ -243,7 +244,7 @@ namespace Padoru.Diagnostics
 
             AddOutput(defaultOutput);
 
-            LogWarning($"Tried to use Padoru.Diagnostics.Debug without configuring it first. Logger auto-configured itself with default options.", "LogInternal");
+            LogWarning($"Tried to use Padoru.Diagnostics.Debug without configuring it first. Logger auto-configured itself with default options.", INTERNAL_CHANNEL_NAME);
         }
         
         #endregion Private Methods

--- a/PadoruLogger/Debug.cs
+++ b/PadoruLogger/Debug.cs
@@ -113,7 +113,6 @@ namespace Padoru.Diagnostics
             InternalLog(LogType.Error, message, channel, context);
         }
         
-        
         public static void LogException(Exception e, string channel)
         {
             LogException(null, e, channel);

--- a/PadoruLogger/Debug.cs
+++ b/PadoruLogger/Debug.cs
@@ -8,8 +8,6 @@ namespace Padoru.Diagnostics
 {
     public static class Debug
     {
-        private const string DEFAULT_CHANNEL_NAME = "Default";
-        
         private static UnityConsoleOutput defaultUnityConsoleOutput;
         private static List<RuntimePlatform> unsupportedPlatforms;
         private static IStackTraceFormatter stackTraceFormatter;
@@ -99,87 +97,26 @@ namespace Padoru.Diagnostics
             outputs.Add(output);
         }
 
-        public static void Log(object message = null)
-        {
-            Log(message, DEFAULT_CHANNEL_NAME, null);
-        }
-
-        public static void Log(object message, string channel)
-        {
-            Log(message, channel, null);
-        }
-
-        public static void Log(object message, object context)
-        {
-            Log(message, DEFAULT_CHANNEL_NAME, context);
-        }
-
-        public static void Log(object message, string channel, object context)
+        public static void Log(object message, string channel, object context=null)
         {
             InternalLog(LogType.Info, message, channel, context);
         }
 
-
-        public static void LogWarning(object message = null)
-        {
-            LogWarning(message, DEFAULT_CHANNEL_NAME, null);
-        }
-
-        public static void LogWarning(object message, string channel)
-        {
-            LogWarning(message, channel, null);
-        }
-
-        public static void LogWarning(object message, object context)
-        {
-            LogWarning(message, DEFAULT_CHANNEL_NAME, context);
-        }
-
-        public static void LogWarning(object message, string channel, object context)
+        public static void LogWarning(object message, string channel, object context=null)
         {
             InternalLog(LogType.Warning, message, channel, context);
         }
 
-        public static void LogError(object message = null)
-        {
-            LogError(message, DEFAULT_CHANNEL_NAME, null);
-        }
-
-        public static void LogError(object message, string channel)
-        {
-            LogError(message, channel, null);
-        }
-
-        public static void LogError(object message, object context)
-        {
-            LogError(message, DEFAULT_CHANNEL_NAME, context);
-        }
-
-        public static void LogError(object message, string channel, object context)
+        public static void LogError(object message, string channel, object context=null)
         {
             InternalLog(LogType.Error, message, channel, context);
         }
 
-        public static void LogException(Exception e)
-        {
-            LogException(null, e, null);
-        }
-
-        public static void LogException(object messageHeader, Exception e)
-        {
-            LogException(messageHeader, e, null);
-        }
-
-        public static void LogException(Exception e, object context)
-        {
-            LogException(null, e, context);
-        }
-        
-        public static void LogException(object messageHeader, Exception e, object context)
+        public static void LogException(object messageHeader, Exception e, string channel, object context=null)
         {
             var message = messageHeader != null ? $"{messageHeader}. {e.Message}" : e.Message;
             
-            InternalLog(LogType.Exception, message, DEFAULT_CHANNEL_NAME, context, e.StackTrace);
+            InternalLog(LogType.Exception, message, channel, context, e.StackTrace);
         }
         #endregion Public Interface
 
@@ -306,7 +243,7 @@ namespace Padoru.Diagnostics
 
             AddOutput(defaultOutput);
 
-            LogWarning($"Tried to use Padoru.Diagnostics.Debug without configuring it first. Logger auto-configured itself with default options.");
+            LogWarning($"Tried to use Padoru.Diagnostics.Debug without configuring it first. Logger auto-configured itself with default options.", "LogInternal");
         }
         
         #endregion Private Methods


### PR DESCRIPTION
#### Description

Consolidated the log methods such that logging to default without specifying a channel is no longer an option.

Now it looks like:
![image](https://github.com/user-attachments/assets/5d9bdb6c-8cd6-4778-b220-5b7ab45b7c5e)


#### Testing plan

Case by case basis, we will need to rollout one-by-one and case by case basis


#### JIRA + Optional Slack context

https://series-ai.atlassian.net/browse/RHO-4290
https://seriesai.slack.com/archives/C04QCDML1AR/p1726674375358839
