### PR TITLE
[RHO-4360] logger-lib - Fully remove deprecated log methods - always require channel

### DIFF
--- a/PadoruLogger/Debug.cs
+++ b/PadoruLogger/Debug.cs
@@ -1,16 +1,12 @@
 ﻿using System;
 using System.Text;
 using System.Collections.Generic;
-using System.ComponentModel.Design;
 using UnityEngine;
 
 namespace Padoru.Diagnostics
 {
     public static class Debug
     {
-        private const string DEFAULT_CHANNEL_NAME = "Default";  // deprecated
-        private const string INTERNAL_CHANNEL_NAME = "PadoruDebug";
-
         private static UnityConsoleOutput defaultUnityConsoleOutput;
         private static List<RuntimePlatform> unsupportedPlatforms;
         private static IStackTraceFormatter stackTraceFormatter;
@@ -96,21 +92,9 @@ namespace Padoru.Diagnostics
             outputs.Add(output);
         }
 
-        [Obsolete("Logging without channel is deprecated, please use an overload with channel instead.")]
-        public static void Log(object message = null)
-        {
-            Log(message, DEFAULT_CHANNEL_NAME, null);
-        }
-
         public static void Log(object message, string channel)
         {
             Log(message, channel, null);
-        }
-
-        [Obsolete("Logging without channel is deprecated, please use an overload with channel instead.")]
-        public static void Log(object message, object context)
-        {
-            Log(message, DEFAULT_CHANNEL_NAME, context);
         }
 
         public static void Log(object message, string channel, object context)
@@ -118,22 +102,9 @@ namespace Padoru.Diagnostics
             InternalLog(LogType.Info, message, channel, context);
         }
 
-
-        [Obsolete("Logging without channel is deprecated, please use an overload with channel instead.")]
-        public static void LogWarning(object message = null)
-        {
-            LogWarning(message, DEFAULT_CHANNEL_NAME, null);
-        }
-
         public static void LogWarning(object message, string channel)
         {
             LogWarning(message, channel, null);
-        }
-
-        [Obsolete("Logging without channel is deprecated, please use an overload with channel instead.")]
-        public static void LogWarning(object message, object context)
-        {
-            LogWarning(message, DEFAULT_CHANNEL_NAME, context);
         }
 
         public static void LogWarning(object message, string channel, object context)
@@ -141,21 +112,9 @@ namespace Padoru.Diagnostics
             InternalLog(LogType.Warning, message, channel, context);
         }
 
-        [Obsolete("Logging without channel is deprecated, please use an overload with channel instead.")]
-        public static void LogError(object message = null)
-        {
-            LogError(message, DEFAULT_CHANNEL_NAME, null);
-        }
-
         public static void LogError(object message, string channel)
         {
             LogError(message, channel, null);
-        }
-
-        [Obsolete("Logging without channel is deprecated, please use an overload with channel instead.")]
-        public static void LogError(object message, object context)
-        {
-            LogError(message, DEFAULT_CHANNEL_NAME, context);
         }
 
         public static void LogError(object message, string channel, object context)
@@ -183,32 +142,6 @@ namespace Padoru.Diagnostics
             var message = messageHeader != null ? $"{messageHeader}. {e.Message}" : e.Message;
             
             InternalLog(LogType.Exception, message, channel, context, e.StackTrace);
-        }
-        
-        [Obsolete("Logging without channel is deprecated, please use an overload with channel instead.")]
-        public static void LogException(Exception e)
-        {
-            LogException(null, e, null);
-        }
-
-        [Obsolete("Logging without channel is deprecated, please use an overload with channel instead.")]
-        public static void LogException(object messageHeader, Exception e)
-        {
-            LogException(messageHeader, e, null);
-        }
-
-        [Obsolete("Logging without channel is deprecated, please use an overload with channel instead.")]
-        public static void LogException(Exception e, object context)
-        {
-            LogException(null, e, context);
-        }
-        
-        [Obsolete("Logging without channel is deprecated, please use an overload with channel instead.")]
-        public static void LogException(object messageHeader, Exception e, object context)
-        {
-            var message = messageHeader != null ? $"{messageHeader}. {e.Message}" : e.Message;
-            
-            InternalLog(LogType.Exception, message, DEFAULT_CHANNEL_NAME, context, e.StackTrace);
         }
         #endregion Public Interface
 

--- a/PadoruLogger/Debug.cs
+++ b/PadoruLogger/Debug.cs
@@ -7,6 +7,8 @@ namespace Padoru.Diagnostics
 {
     public static class Debug
     {
+        private const string INTERNAL_CHANNEL_NAME = "PadoruDebug";
+        
         private static UnityConsoleOutput defaultUnityConsoleOutput;
         private static List<RuntimePlatform> unsupportedPlatforms;
         private static IStackTraceFormatter stackTraceFormatter;

--- a/PadoruLogger/Debug.cs
+++ b/PadoruLogger/Debug.cs
@@ -8,7 +8,7 @@ namespace Padoru.Diagnostics
     public static class Debug
     {
         private const string INTERNAL_CHANNEL_NAME = "PadoruDebug";
-        
+
         private static UnityConsoleOutput defaultUnityConsoleOutput;
         private static List<RuntimePlatform> unsupportedPlatforms;
         private static IStackTraceFormatter stackTraceFormatter;
@@ -16,7 +16,7 @@ namespace Padoru.Diagnostics
         private static LogSettings settings;
         private static List<IDebugOutput> outputs;
         private static bool isConfigured;
-               
+
         #region Public Interface
         /// <summary>
         /// Mandatory method to start using the logger
@@ -72,7 +72,7 @@ namespace Padoru.Diagnostics
                 }
 
                 unsupportedPlatforms = settings.UnsupportedPlatforms;
-                
+
                 outputs = new List<IDebugOutput>();
 
                 isConfigured = true;
@@ -138,7 +138,7 @@ namespace Padoru.Diagnostics
         {
             LogException(null, channel, e, context);
         }
-        
+
         public static void LogException(object messageHeader, string channel, Exception e, object context)
         {
             var message = messageHeader != null ? $"{messageHeader}. {e.Message}" : e.Message;
@@ -148,7 +148,6 @@ namespace Padoru.Diagnostics
         #endregion Public Interface
 
         #region Private Methods
-
         private static void InternalLog(LogType logType, object message, string channel, object context, string stackTrace = null)
         {
             message = message ?? string.Empty;
@@ -273,7 +272,6 @@ namespace Padoru.Diagnostics
 
             LogWarning($"Tried to use Padoru.Diagnostics.Debug without configuring it first. Logger auto-configured itself with default options.", INTERNAL_CHANNEL_NAME);
         }
-        
         #endregion Private Methods
     }
 }


### PR DESCRIPTION
#### Description
Removes deprecated log methods that allow omission of log channel. The deprecation warnings were added as step towards final removal back in the fall, and now with most people in the habit of using and most call sites taken care of, I'm removing them fully now.

Other relevant PRs:
https://github.com/series-ai/core-lib/pull/20
https://github.com/series-ai/unity-package-core/pull/59
https://github.com/series-ai/cadmus/pull/1920
https://github.com/series-ai/audio-lib/pull/1
https://github.com/series-ai/unity-package-avatar-2d/pull/416

Final PR to update packages:
https://github.com/series-ai/cadmus/pull/1928

The original PR of PRs to deprecate and change a bulk of the callsites at the time to use channels:
https://github.com/series-ai/cadmus/pull/1462

#### Testing plan
Check for compiler errors, use in corelib locally and ensure that no issues across other repos.

#### JIRA + Optional Slack context
https://series-ai.atlassian.net/browse/RHO-4360
